### PR TITLE
Simplify LUD-21 and add example flow

### DIFF
--- a/21.md
+++ b/21.md
@@ -1,13 +1,25 @@
-LUD-21: Pay in local unit of account.
-================================================
+LUD-21: Pay in local unit of account
+====================================
 
 `author: ethanrose`
 
 ---
 
-The idea here is to enable a merchant to receive an exact payment amount, in whatever currency their goods are priced in (i.e. their own fiat currency). A sender should be able to input the amount in the recipient's own unit of account.
+The idea here is to enable a merchant to receive an exact payment amount, in whatever currency their goods are priced in (i.e. their own fiat currency). A sender should be able to input the amount in the recipient's own unit of account. This is required for static (think printed) QR codes with no predefined amount when the buyer himself is going to input the amount manually.
 
-Typically this is for a point-of-sale use-case where a lightning service is acting as a bitcoin-to-fiat payment processor. Currently, a sender would have to use their own calculator to determine how many sats to pay, and the recipient inevitably would receive the close-but-wrong amount. This bad experience is a hinderance to adoption of lightning as a cross-border payment system.
+## Description of the payment flow
+
+For example, a merchant is pricing their goods in a made-up currency, let's call it "USD". This may or may not have any relationship with the actual United States Dollar, the name is just illustrative. The merchant has a static QR code on his stall that customers can scan. The flow goes like this:
+
+1. Customer picks up a good they want to buy;
+2. Merchant shows them the QR code, they scan it;
+3. The merchant's LNURL-Pay server (say, at "https://merchant.example.com") returns a response that contains a "multiplier" for units in the "USD" currency to be turned into millisatoshis, along with a cosmetic name for the currency (in this case, "USD") _(see section 1 below)_;
+4. The customer sees a screen on their Lightning wallet that says something like: `The vendor 'merchant.example.com' expects an amount in its own currency, "USD"` and then it has an input field for the amount to be typed in, then a clear depiction of the multiplier (suppose it's `3520000` for "USD") and the result in satoshis: `______ × 3520.000 = ______ satoshis`;
+5. Merchant tells customer the price of the chosen good (let's say it's `2` "USD");
+6. Customer types the amount and sees `2 × 3520.000 = 7040 satoshis`, presses ok;
+7. Wallet calls the merchant's LNURL-Pay server with the amount in millisatoshis along with the amount in the merchant's currency and the merchant's currency name _(see section 2 below)_;
+8. The merchant's LNURL-Pay server validates the request using its internal multipler and returns the Lightning invoice as in LUD-06, _with the same amount specified in the amount query parameter_, or an error if the multiplier used by the wallet is invalid or wrong somehow.
+9. Wallet checks the amount, as in LUD-06, and proceeds.
 
 ## 1. `currency` record in payRequest details
 
@@ -20,9 +32,7 @@ If `SERVICE` wishes for a `WALLET` user to specify a payment amount in a differe
    "minSendable": number,
    "metadata": string,
 +  "currency": {
-+    "code": "PHP",
-+    "name": "Philippine Pesos",
-+    "symbol": "₱",
++    "name": "USD",
 +    "minSendable": 1,
 +    "maxSendable": 50000,
 +    "multiplier": 64501 // estimated millisats per "unit"
@@ -31,27 +41,11 @@ If `SERVICE` wishes for a `WALLET` user to specify a payment amount in a differe
  }
 ```
 
-NOTE: `SERVICE` must include a `multiplier` property. This is an estimate which helps the `WALLET` do frontend validation & set expectations for users. A simple helper for the `SERVICE` to calculate millisats `multiplier` from common BTC rates is:
+## 2. Including `currency` in callback parameters
 
-```
-10**11 / btcRate
-```
-
-## 2. User interface for specifying currency
-
-If there is a `currency` record in the initial response, `WALLET` must display a modified interface:
-- The wallet must display the `currency.code` and/or `currency.name` instead of its default currency.
-- The wallet must enforce `currency.minSendable` and `currency.maxSendable`.
-
-## 3. Including `currency` in callback parameters
-
-In the next step of the LNURL-Pay flow, `WALLET` must include a `currency` query parameter in the callback along with the `amount`:
+In the next step of the LNURL-Pay flow, `WALLET` must include a `currencyAmount` and `currencyName` query parameters in the callback along with the `amount`:
 
 ```diff
 - <callback><?|&>amount=<milliSatoshi>
-+ <callback><?|&>amount=<philippinePeso>&currency=PHP
++ <callback><?|&>amount=<millisatoshi>&currencyAmount=<amountInMerchantCurrency>&currencyName=USD
 ```
-
-## 4. User interface for reviewing & confirming the exchange rate
-
-- `WALLET` must display a confirmation screen so that the user can review/verify and "approve" or "confirm" the resulting invoice amount.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These are all the individual documents describing each small piece of protocol t
 | [18][18] | Payer identity in `payRequest` protocol.                    | [Blixt][blixt], [cliché][cliche], [ZBD Discord][zbd], [ZBD Telegram][zbd] |
 | [19][19] | Pay link discoverable from withdraw link.                   | [Blixt][blixt], [CoinCorner][coincorner], [SimpleBitcoinWallet][sbw] |
 | [20][20] | Long payment description for pay protocol.                  | [Alby][alby], [Blixt][blixt], [Clams][clams], [cliché][cliche], [Phoenix][phoenix] |
-| [21][21] | Pay in local unit of account.                               | [Pouch.ph][pouchph]
+| [21][21] | Pay in local unit of account                                | [Pouch.ph][pouchph]
 
 [alby]: https://github.com/getAlby/lightning-browser-extension
 [bos]: https://github.com/alexbosworth/balanceofsatoshis


### PR DESCRIPTION
Basically I've removed currency symbols and whatnot. These things can be hardcoded by the wallets and do not need to be sent in every request. Also they do not exist in the case of a completely made-up currency, so the protocol should not dictate their usage, and it should be as simple as possible.

Also included an example that hopefully clarifies the use case and how arbitrary currencies can be used in day-to-day shopping with this simple LUD without breaking any trust. Basically I think there an element of deceitfulness that can be integrated if the names of well-known government currencies are used along with exchange rates that are expected to be "correct" -- but this is all based on a illusion, because such exchange rates do not really exist, they are subjective, and making this clear in the UX and in the protocol is a good thing.

Also changed the way the query string parameters are sent such that the wallet can just the `amount` as always and the server can check the implied multiplier by doing `amount/currencyAmount`, but also the server can still just check just the `amount` in bare millisatoshis if the wallet doesn't implement this LUD and hopefully it can still work.

Readable document: https://github.com/lnurl/luds/blob/local-currency-multiplier/21.md